### PR TITLE
dropping S3 Variable

### DIFF
--- a/terraform/cloudzero-resource/varriables.tf
+++ b/terraform/cloudzero-resource/varriables.tf
@@ -2,8 +2,3 @@ variable "cloudzero_external_id" {
   type = string
   description = "The CloudZero provided External ID for your cross account access role (Your ID can be found on the CloudZero manual account connection page)"
 }
-
-variable "AWS_CUR_bucket" {
-  type = string
-  description = "The S3 bucket where your AWS CUR is stored. Please ensure you have configured your CUR according to these instructions https://docs.cloudzero.com/docs/validate-your-cost-and-usage-report"
-}


### PR DESCRIPTION
## Description of the change

The new structure of the terraform breaks up the provisioning workflows into two different directory structures.  However, they were both using the same variables.tf file.  In this PR the requirement to provide the path to the S3 bucket for the CUR file has been removed from the cloudzero-resource terraform.

## Type of change
- [ ] Bug fix
- [ ] New feature

## Checklists
None

### Development
- [ ] All changes have been verified by running terraform plan and terraform apply against an AWS sub-account (resource account).
### Code review 
- [ ] Not applicable.
