### PR TITLE
Update to support cloudformation stacksets

### DIFF
--- a/services/account_type/resource_owner.yaml
+++ b/services/account_type/resource_owner.yaml
@@ -15,10 +15,17 @@ Parameters:
     Type: String
     Description: |
       CloudZero AWS AccountID; for cross-account Role Access
+    Default: "061190967865"
   IsResourceOwnerAccount:
     Type: String
     Description: |
       Should this template instantiate any resources?
+  ResourcesOwnerRoleName:
+    Type: String
+    Description: |
+      Name of the Role to be created in the resource account. This must be identical
+      in every resource account.
+    Default: "CloudzeroConnectedAccountResourceOwnerRole"
 
 Conditions:
   CreateResources: !Equals [ !Ref IsResourceOwnerAccount, 'true' ]
@@ -28,6 +35,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: CreateResources
     Properties:
+      RoleName: ${ResourceOwnerRoleName}
       Path: '/cloudzero/'
       AssumeRolePolicyDocument:
         Version: 2012-10-17


### PR DESCRIPTION
## Description of the change

> modified cloudformation resource_owner.yaml to include a static role name for use with stacksets. this will enable customers to connect all AWS accounts in a AWS Organization to be connected to Cloudzero as resource accounts by using stacksets.


## Type of change
- [ ] Bug fix
- [X] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
