### PR TITLE
updated services/account_type/resource_owner.yaml with new default values

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @cloudzero/not-found

--- a/policies/master_payer.json
+++ b/policies/master_payer.json
@@ -14,7 +14,7 @@
       ]
     },
     {
-      "Sid": "CZCostMonitoring20230119",
+      "Sid": "CZCostMonitoring20240422",
       "Effect": "Allow",
       "Action": [
         "account:GetAccountInformation",
@@ -29,6 +29,7 @@
         "cur:Describe*",
         "cur:Get*",
         "cur:Validate*",
+        "cur:List*",
         "freetier:Get*",
         "invoicing:Get*",
         "invoicing:List*",

--- a/policies/resource_owner.json
+++ b/policies/resource_owner.json
@@ -2,7 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "CZCostMonitoring20230119",
+      "Sid": "CZCostMonitoring20240422",
       "Effect": "Allow",
       "Action": [
         "account:GetAccountInformation",
@@ -17,6 +17,7 @@
         "cur:Describe*",
         "cur:Get*",
         "cur:Validate*",
+        "cur:List*",
         "freetier:Get*",
         "invoicing:Get*",
         "invoicing:List*",

--- a/services/account_type/master_payer.yaml
+++ b/services/account_type/master_payer.yaml
@@ -270,7 +270,7 @@ Resources:
                   - 'arn:aws:s3:::${BucketName}-${Id}/*'
                   - { BucketName: !FindInMap [ Defaults, Cur, BucketName ],
                       Id: !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] }
-          - Sid: CZCostMonitoring20230119
+          - Sid: CZCostMonitoring20240422
             Effect: Allow
             Action:
               - account:GetAccountInformation
@@ -285,6 +285,7 @@ Resources:
               - cur:Describe*
               - cur:Get*
               - cur:Validate*
+              - cur:List*
               - freetier:Get*
               - invoicing:Get*
               - invoicing:List*

--- a/services/account_type/resource_owner.yaml
+++ b/services/account_type/resource_owner.yaml
@@ -63,7 +63,7 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: CZCostMonitoring20230119
+          - Sid: CZCostMonitoring20240422
             Effect: Allow
             Action:
               - account:GetAccountInformation
@@ -78,6 +78,7 @@ Resources:
               - cur:Describe*
               - cur:Get*
               - cur:Validate*
+              - cur:List*
               - freetier:Get*
               - invoicing:Get*
               - invoicing:List*

--- a/services/account_type/resource_owner.yaml
+++ b/services/account_type/resource_owner.yaml
@@ -20,12 +20,12 @@ Parameters:
     Type: String
     Description: |
       Should this template instantiate any resources?
-  ResourcesOwnerRoleName:
+  ResourceOwnerRoleNameParam:
     Type: String
     Description: |
       Name of the Role to be created in the resource account. This must be identical
       in every resource account.
-    Default: "CloudzeroConnectedAccountResourceOwnerRole"
+    Default: "CloudzeroResourceOwnerRole"
 
 Conditions:
   CreateResources: !Equals [ !Ref IsResourceOwnerAccount, 'true' ]
@@ -35,7 +35,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: CreateResources
     Properties:
-      RoleName: ${ResourceOwnerRoleName}
+      RoleName: !Ref ResourceOwnerRoleNameParam
       Path: '/cloudzero/'
       AssumeRolePolicyDocument:
         Version: 2012-10-17

--- a/services/account_type/resource_owner.yaml
+++ b/services/account_type/resource_owner.yaml
@@ -15,10 +15,17 @@ Parameters:
     Type: String
     Description: |
       CloudZero AWS AccountID; for cross-account Role Access
+    Default: "061190967865"
   IsResourceOwnerAccount:
     Type: String
     Description: |
       Should this template instantiate any resources?
+  ResourcesOwnerRoleName:
+    Type: String
+    Description: |
+      Name of the Role to be created in the resource account. This must be identical
+      in every resource account.
+    Default: "CloudzeroConnectedAccountResourceOwnerRole"
 
 Conditions:
   CreateResources: !Equals [ !Ref IsResourceOwnerAccount, 'true' ]
@@ -28,6 +35,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: CreateResources
     Properties:
+      RoleName: ${ResourceOwnerRoleName}
       Path: '/cloudzero/'
       AssumeRolePolicyDocument:
         Version: 2012-10-17


### PR DESCRIPTION
## Description of the change

> Updated services/account_type/resource_owner.yaml to include default value for AWS account, and added "ResourceOnwerRoleName" with a default value so that the resource_owner.yaml CloudFormation can be used to deploy a stackset for adding resource accounts.

## Type of change
- [ ] Bug fix
- [X] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
