### PR TITLE
Fixing the CI workflow to not run on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ name: CI
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
     branches:
       - develop

--- a/docs/releases/1.0.84.md
+++ b/docs/releases/1.0.84.md
@@ -1,0 +1,7 @@
+# [1.0.84](https://github.com/Cloudzero/provision-account/compare/1.0.83...1.0.84) (2024-11-20)
+
+> Fixing the CI workflow to not run on push.
+
+## Bug Fixes
+
+* **CI:** Fixing the CI workflow to not run on push. This was leftover from testing on 1.0.83


### PR DESCRIPTION
## Description of the change

> Fixing the CI workflow to not run on push

## Type of change
- [x] Bug fix
- [ ] New feature

## Checklists

### Development
- [x] All changed code has 80% unit test coverage
- [x] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [x]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
