### PR TITLE
CP-26586 Add PowerShell script for easier Azure MCA or EA connection setup

### DIFF
--- a/azure/cz_azure_billing_permissions_setup.ps1
+++ b/azure/cz_azure_billing_permissions_setup.ps1
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+#
+# This PowerShell script grants CloudZero the necessary permissions to connect
+# your Azure EA or MCA account to CloudZero.
+#
+# Use this script instead of "Step 4: Grant Access to the Azure Billing API" in the documentation:
+# - EA accounts: https://docs.cloudzero.com/docs/connections-azure-ea#step-4-grant-access-to-the-azure-billing-api
+# - MCA accounts: https://docs.cloudzero.com/docs/connections-azure-mca#step-4-grant-access-to-the-azure-billing-api
 
 [CmdletBinding()]
 param (
@@ -18,7 +25,7 @@ $resultObject = @{}
 $ErrorActionPreference = 'Stop' # Stop if we get any errors
 
 ######################################################################################################
-# Setup and validate important information
+# Set up and validate important information
 ######################################################################################################
 $currentUser = Get-AzContext
 
@@ -73,7 +80,7 @@ $resultObject.AgreementType = $billingAccountInfo.AgreementType
 #
 # There are some aspects cost data that are not present in the exported data. This includes items like
 # taxes and fees. To get these costs, the CloudZeroPlatform Service Principal must have read access
-# to the Billing Account (Microsoft Customer Agreement) or the Enrollment Account (Enterprise Agreemeent).
+# to the Billing Account (Microsoft Customer Agreement) or the Enrollment Account (Enterprise Agreement).
 # This read access gives the CloudZero platform access to invoices.
 ######################################################################################################
 

--- a/azure/cz_azure_billing_permissions_setup.ps1
+++ b/azure/cz_azure_billing_permissions_setup.ps1
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
+# Licensed under the Apache 2.0 license. See LICENSE file in the project root for full license information.
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]
+    $BillingAccountId,
+    # For internal use only
+    [Parameter()]
+    [switch]
+    $DevEnv
+)
+
+$resultObject = @{}
+
+$ErrorActionPreference = 'Stop' # Stop if we get any errors
+
+######################################################################################################
+# Setup and validate important information
+######################################################################################################
+$currentUser = Get-AzContext
+
+Write-Debug "AzContext: $(ConvertTo-Json -InputObject $currentUser)"
+
+$currentTenantId = $currentUser.Tenant.Id
+
+$resultObject.TenantId = $currentUser.Tenant.Id
+
+$cloudZeroServicePrincipalName = if ($DevEnv) {"CloudZeroPlatformDev"} else {"CloudZeroPlatform"}
+$cloudZeroServicePrincipal = Get-AzADServicePrincipal -DisplayName $cloudZeroServicePrincipalName
+
+if (!$cloudZeroServicePrincipal) {
+    throw "Cannot find the Service Principal '$($cloudZeroServicePrincipalName). You must first complete the consent process. See the CloudZero application."
+}
+
+Write-Debug "CloudZero SPN: $(ConvertTo-Json -InputObject $cloudZeroServicePrincipal)"
+$resultObject.CloudZeroSpnId = $cloudZeroServicePrincipal.Id
+
+$microsoftCustomerAgreement = "MicrosoftCustomerAgreement"
+$enterpriseAgreement = "EnterpriseAgreement"
+$validAgreementTypes = @($microsoftCustomerAgreement, $enterpriseAgreement)
+
+
+######################################################################################################
+# Get the billing account information and validate it
+#
+# The CloudZeroPlatform must know what type of agreement is in use as there are differences in how
+# cost data is presented in the different agreement types.
+######################################################################################################
+$billingAccountInfo = if ($BillingAccountId) { (Get-AzBillingAccount -Name $BillingAccountId) } else { (Get-AzBillingAccount) }
+
+Write-Debug "Billing Account: $(ConvertTo-Json -InputObject $billingAccountInfo)"
+
+if ($billingAccountInfo.Length -gt 1) {
+    Write-Error $billingAccountInfo
+    throw "There are multiple billing accounts. You must select the billing account you are going to monitor on the CloudZero platform."
+}
+
+if (!($billingAccountInfo.AgreementType -in $validAgreementTypes)) {
+    Write-Error $billingAccountInfo
+    throw "Agreement type '$($billingAccountInfo.AgreementType)' is not supported. Supported agreement types: $($validAgreementTypes -join ", "))"
+}
+
+$resultObject.BillingAccountName = $billingAccountInfo.DisplayName
+$resultObject.BillingAccountId = $billingAccountInfo.Name
+$resultObject.AgreementType = $billingAccountInfo.AgreementType
+
+
+######################################################################################################
+# Set read only permissions on the billing account for the CloudZeroPlatform Service Principal
+#
+# There are some aspects cost data that are not present in the exported data. This includes items like
+# taxes and fees. To get these costs, the CloudZeroPlatform Service Principal must have read access
+# to the Billing Account (Microsoft Customer Agreement) or the Enrollment Account (Enterprise Agreemeent).
+# This read access gives the CloudZero platform access to invoices.
+######################################################################################################
+
+$getBillingRoleAssignmentPath = "/providers/Microsoft.Billing/billingAccounts/$($billingAccountInfo.Name)/billingRoleAssignments?api-version=2019-10-01-preview"
+$billingReaderRoleId = if ($billingAccountInfo.AgreementType -eq $enterpriseAgreement) {"24f8edb6-1668-4659-b5e2-40bb5f3a7d7e"} else {"50000000-aaaa-bbbb-cccc-100000000002"}
+$billingReaderRoleDefinitionId = "/providers/Microsoft.Billing/billingAccounts/$($billingAccountInfo.Name)/billingRoleDefinitions/$($billingReaderRoleId)"
+
+$billingRoleAssignmentsResult = Invoke-AzRestMethod -Path $getBillingRoleAssignmentPath -Method GET
+
+$addBillingReaderRole = $true
+
+# First check to see if the service principal has already been assigned the reader role
+if ($billingRoleAssignmentsResult) {
+    $billingRoleAssignments = ConvertFrom-Json -InputObject $billingRoleAssignmentsResult.Content
+    Write-Debug "Checking Billing Role Assigment: $(ConvertTo-Json -InputObject $billingRoleAssignments.value)"
+    foreach ($billingRoleAssignment in $billingRoleAssignments.value) {
+        if ($billingRoleAssignment.properties.principalId -eq $cloudZeroServicePrincipal.Id `
+            -and $billingRoleAssignment.properties.principalTenantId -eq $currentTenantId `
+            -and $billingRoleAssignment.properties.roleDefinitionId -eq $billingReaderRoleDefinitionId) {
+            $addBillingReaderRole = $false
+            Write-Host "Billing reader role is already assigned to $($cloudZeroServicePrincipal.DisplayName) service principal."
+        }
+    }
+}
+
+# If we have not found the correct role assignment, then assign the role. The API to assign the role is different for EA and MCA accounts
+if ($addBillingReaderRole) {
+    if ($billingAccountInfo.AgreementType -eq $enterpriseAgreement) {
+        $billingRoleAssignmentId = (New-Guid).Guid
+        $putBillingRoleAssignmentPath = "/providers/Microsoft.Billing/billingAccounts/$($billingAccountInfo.Name)/billingRoleAssignments/$($billingRoleAssignmentId)?api-version=2019-10-01-preview"
+
+        $props = @{
+            properties = @{
+                principalId = $cloudZeroServicePrincipal.Id
+                principalTenantId = $currentTenantId
+                roleDefinitionId = $billingReaderRoleDefinitionId
+            }
+        }
+    
+        $result = Invoke-AzRestMethod -Path $putBillingRoleAssignmentPath -Method PUT -Payload (ConvertTo-Json -InputObject $props)
+
+        if (!($result.StatusCode -lt 300)) {
+            Write-Error $result
+            throw "A failure occurred assigning billing reader access to CloudZero service principal."
+        }
+
+    } else {
+        $postBillingRoleAssignmentPath = "/providers/Microsoft.Billing/billingAccounts/$($billingAccountInfo.Name)/createBillingRoleAssignment?api-version=2019-10-01-preview"
+
+        $props = @{
+            properties = @{
+                principalId = $cloudZeroServicePrincipal.Id
+                roleDefinitionId = $billingReaderRoleDefinitionId
+            }
+        }
+
+        $result = Invoke-AzRestMethod -Path $postBillingRoleAssignmentPath -Method POST -Payload (ConvertTo-Json -InputObject $props)
+
+        if (!($result.StatusCode -lt 300)) {
+            Write-Error $result
+            throw "A failure occurred assigning billing reader access to $($cloudZeroServicePrincipal.DisplayName) service principal."
+        }
+        else {
+            Write-Host "Added read only permissions for the billing account to $($cloudZeroServicePrincipal.DisplayName) service principal."
+        }
+    }
+}
+
+$resultObject.BillingReaderRoleAdded = $true
+
+Write-Output $resultObject

--- a/docs/releases/1.0.85.md
+++ b/docs/releases/1.0.85.md
@@ -1,0 +1,7 @@
+# [1.0.85](https://github.com/Cloudzero/provision-account/compare/1.0.84...1.0.85) (2025-03-06)
+
+> Adding Azure connection permissions setup script to the provision-account project.
+
+## New Features
+
+* **Azure Connection Setup Script:** Added a PowerShell script to make it easier to connect an [Azure EA](https://docs.cloudzero.com/docs/connections-azure-ea) or [MCA](https://docs.cloudzero.com/docs/connections-azure-mca) account to CloudZero. The script grants the CloudZero service principal the necessary permissions to access Azure's Cost Management & Billing APIs.

--- a/docs/releases/1.0.86.md
+++ b/docs/releases/1.0.86.md
@@ -1,4 +1,4 @@
-# [1.0.85](https://github.com/Cloudzero/provision-account/compare/1.0.84...1.0.85) (2025-03-06)
+# [1.0.86](https://github.com/Cloudzero/provision-account/compare/1.0.85...1.0.86) (2025-03-10)
 
 > Adding Azure connection permissions setup script to the provision-account project.
 


### PR DESCRIPTION
## Description of the change

This PR adds a PowerShell script that grants CloudZero the necessary permissions to connect to an Azure EA or MCA account.

Users can run the script instead of following the steps in **Step 4: Grant Access to the Azure Billing API** in the [EA setup guide](https://docs.cloudzero.com/docs/connections-azure-ea#step-4-grant-access-to-the-azure-billing-api) and [MCA setup guide](https://docs.cloudzero.com/docs/connections-azure-mca#step-4-grant-access-to-the-azure-billing-api).

We will add a link to this script from the docs site.

## Type of change
- [ ] Bug fix
- [x] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
