### PR TITLE
CP-40732: support parquet ingest natively

### DIFF
--- a/docs/releases/1.0.94.md
+++ b/docs/releases/1.0.94.md
@@ -1,0 +1,21 @@
+# [1.0.94](https://github.com/Cloudzero/provision-account/compare/1.0.93...1.0.94) (2026-04-29)
+
+> Add native Parquet CUR support to discovery and notification
+
+## New Features
+
+### Parquet CUR Discovery
+* **Widen CUR matching to accept Parquet format** — `IDEAL_BILLING_REPORT` and `MINIMUM_BILLING_REPORT` schemas now match both `textORcsv` and `Parquet` CURs. Customers with an existing Parquet CUR are matched on first run — no new CSV CUR is created, preserving full report history.
+* **CSV takes priority** — if a customer has both a CSV and Parquet CUR, the CSV match wins so existing connections are unaffected.
+* **`BillingReportFormat` discovery output** — discovery now emits `aws_parquet` when a Parquet CUR is matched, `aws` otherwise. Added as a CloudFormation stack output so downstream stacks can read it.
+
+### Notification
+* **Forward `billing_report_format` in `account-link-provisioned` message** — notification reads `BillingReportFormat` from the Discovery CFN stack output and includes it in the outgoing message metadata, defaulting to `aws` if absent. reactor-manager-account reads this value on the auto-link path.
+
+## Files Modified
+
+- `services/discovery/src/app.py`
+- `services/discovery/template.yaml`
+- `services/discovery/tests/unit/test_app.py`
+- `services/notification/src/app.py`
+- `services/notification/tests/unit/test_app.py`

--- a/services/discovery/src/app.py
+++ b/services/discovery/src/app.py
@@ -264,11 +264,13 @@ MINIMUM_BILLING_REPORT_PARQUET = Schema({
     'RefreshClosedReports': bool,
 }, extra=ALLOW_EXTRA, required=True)
 
-# CSV tiers evaluated before Parquet — if a customer has both, CSV wins to preserve existing behavior.
+# All CSV tiers are evaluated before any Parquet tier so that CSV wins unconditionally when both formats exist.
+# Customers whose Parquet CUR was previously undetected had a CSV CUR created for them by this stack — if
+# Parquet were matched on a subsequent stack update, their existing CSV connection could receive duplicate data.
 _CUR_CANDIDATE_TIERS = [
     (IDEAL_BILLING_REPORT_CSV, 'aws'),
-    (IDEAL_BILLING_REPORT_PARQUET, 'aws_parquet'),
     (MINIMUM_BILLING_REPORT_CSV, 'aws'),
+    (IDEAL_BILLING_REPORT_PARQUET, 'aws_parquet'),
     (MINIMUM_BILLING_REPORT_PARQUET, 'aws_parquet'),
 ]
 

--- a/services/discovery/src/app.py
+++ b/services/discovery/src/app.py
@@ -34,6 +34,7 @@ DEFAULT_OUTPUT = {
     'IsMasterPayerAccount': False,
     'MasterPayerBillingBucketName': None,
     'MasterPayerBillingBucketPath': None,
+    'BillingReportFormat': 'aws',
     'IsAccountOutsideOrganization': False,
 }
 
@@ -219,7 +220,7 @@ def discover_cloudtrail_account(world):
     return update_in(world, ['output'], lambda x: merge(x or {}, output))
 
 
-IDEAL_BILLING_REPORT = Schema({
+IDEAL_BILLING_REPORT_CSV = Schema({
     'TimeUnit': 'HOURLY',
     'Format': 'textORcsv',
     'Compression': 'GZIP',
@@ -231,7 +232,19 @@ IDEAL_BILLING_REPORT = Schema({
     'RefreshClosedReports': True,
 }, extra=ALLOW_EXTRA, required=True)
 
-MINIMUM_BILLING_REPORT = Schema({
+IDEAL_BILLING_REPORT_PARQUET = Schema({
+    'TimeUnit': 'HOURLY',
+    'Format': 'Parquet',
+    'Compression': 'Parquet',
+    'AdditionalSchemaElements': ExactSequence(['RESOURCES']),
+    'S3Bucket': str,
+    'S3Prefix': str,
+    'S3Region': str,
+    'ReportVersioning': 'CREATE_NEW_REPORT',
+    'RefreshClosedReports': True,
+}, extra=ALLOW_EXTRA, required=True)
+
+MINIMUM_BILLING_REPORT_CSV = Schema({
     'TimeUnit': 'HOURLY',
     'Format': 'textORcsv',
     'Compression': 'GZIP',
@@ -241,35 +254,47 @@ MINIMUM_BILLING_REPORT = Schema({
     'RefreshClosedReports': bool,
 }, extra=ALLOW_EXTRA, required=True)
 
+MINIMUM_BILLING_REPORT_PARQUET = Schema({
+    'TimeUnit': 'HOURLY',
+    'Format': 'Parquet',
+    'Compression': 'Parquet',
+    'S3Bucket': str,
+    'S3Prefix': str,
+    'S3Region': str,
+    'RefreshClosedReports': bool,
+}, extra=ALLOW_EXTRA, required=True)
+
+# CSV tiers evaluated before Parquet — if a customer has both, CSV wins to preserve existing behavior.
+_CUR_CANDIDATE_TIERS = [
+    (IDEAL_BILLING_REPORT_CSV, 'aws'),
+    (IDEAL_BILLING_REPORT_PARQUET, 'aws_parquet'),
+    (MINIMUM_BILLING_REPORT_CSV, 'aws'),
+    (MINIMUM_BILLING_REPORT_PARQUET, 'aws_parquet'),
+]
+
 
 def get_first_valid_report_definition(valid_report_definitions, default=None):
     return valid_report_definitions[0] if any(valid_report_definitions) else default
+
+
+def _report_to_bucket_info(report):
+    bucket_name = report.get('S3Bucket')
+    bucket_path = f"{report.get('S3Prefix', '')}/{report.get('ReportName', '')}" if bucket_name else None
+    return bucket_name, bucket_path
 
 
 def get_cur_bucket_if_local(world, report_definitions):
     logger.info(f'Found these ReportDefinitions: {report_definitions}')
     local_buckets = {x['Name'] for x in coeffects_buckets(world)}
 
-    # Try to find ideal reports first (with CREATE_NEW_REPORT)
-    ideal_report_definitions = keep_valid(IDEAL_BILLING_REPORT, report_definitions)
-    logger.info(f'Found these _ideal_ ReportDefinitions: {ideal_report_definitions}')
-    ideal_local_report_definitions = [x for x in ideal_report_definitions if x['S3Bucket'] in local_buckets]
-    logger.info(f'Found these _ideal local_ ReportDefinitions: {ideal_local_report_definitions}')
+    for schema, billing_report_format in _CUR_CANDIDATE_TIERS:
+        local_matches = [r for r in keep_valid(schema, report_definitions) if r['S3Bucket'] in local_buckets]
+        logger.info(f'CUR tier {billing_report_format}: {local_matches}')
+        if local_matches:
+            bucket_name, bucket_path = _report_to_bucket_info(get_first_valid_report_definition(local_matches))
+            return bucket_name, bucket_path, billing_report_format
 
-    # Fall back to minimum requirements if no ideal reports found
-    if not ideal_local_report_definitions:
-        logger.info('No ideal reports found, falling back to minimum requirements')
-        valid_report_definitions = keep_valid(MINIMUM_BILLING_REPORT, report_definitions)
-        logger.info(f'Found these _valid_ ReportDefinitions: {valid_report_definitions}')
-        valid_local_report_definitions = [x for x in valid_report_definitions if x['S3Bucket'] in local_buckets]
-        logger.info(f'Found these _valid local_ ReportDefinitions: {valid_local_report_definitions}')
-        first_valid_local = get_first_valid_report_definition(valid_local_report_definitions, default={})
-    else:
-        first_valid_local = get_first_valid_report_definition(ideal_local_report_definitions, default={})
-
-    bucket_name = first_valid_local.get('S3Bucket')
-    bucket_path = f"{first_valid_local.get('S3Prefix', '')}/{first_valid_local.get('ReportName', '')}" if bucket_name else None
-    return (bucket_name, bucket_path)
+    return None, None, 'aws'
 
 
 def discover_master_payer_account(world):
@@ -277,11 +302,12 @@ def discover_master_payer_account(world):
     is_account_organization_master_account = output_is_organization_master(world)
     is_master_payer = is_account_not_in_organization or is_account_organization_master_account
     report_definitions = coeffects_payer_reports(world)['report_definitions']
-    (bucket_name, bucket_path) = get_cur_bucket_if_local(world, report_definitions)
+    bucket_name, bucket_path, billing_report_format = get_cur_bucket_if_local(world, report_definitions)
     output = {
         'IsMasterPayerAccount': is_master_payer,
         'MasterPayerBillingBucketName': bucket_name,
         'MasterPayerBillingBucketPath': bucket_path,
+        'BillingReportFormat': billing_report_format,
     }
     return update_in(world, ['output'], lambda x: merge(x or {}, output))
 

--- a/services/discovery/template.yaml
+++ b/services/discovery/template.yaml
@@ -70,6 +70,8 @@ Outputs:
     Value: !GetAtt DiscoveryResource.MasterPayerBillingBucketName
   MasterPayerBillingBucketPath:
     Value: !GetAtt DiscoveryResource.MasterPayerBillingBucketPath
+  BillingReportFormat:
+    Value: !GetAtt DiscoveryResource.BillingReportFormat
   RemoteCloudTrailBucket:
     Value: !GetAtt DiscoveryResource.RemoteCloudTrailBucket
   VisibleCloudTrailArns:

--- a/services/discovery/tests/unit/test_app.py
+++ b/services/discovery/tests/unit/test_app.py
@@ -225,7 +225,6 @@ CSV_REPORT = {
 }
 
 
-
 @pytest.fixture()
 def describe_report_definitions_response_invalid():
     return {

--- a/services/discovery/tests/unit/test_app.py
+++ b/services/discovery/tests/unit/test_app.py
@@ -224,6 +224,17 @@ CSV_REPORT = {
     'ReportVersioning': 'CREATE_NEW_REPORT',
 }
 
+MINIMUM_CSV_REPORT = {
+    'ReportName': 'minimum-csv-report',
+    'TimeUnit': 'HOURLY',
+    'Format': 'textORcsv',
+    'Compression': 'GZIP',
+    'S3Bucket': LOCAL_BUCKET_NAME,
+    'S3Prefix': 'reports',
+    'S3Region': 'us-east-1',
+    'RefreshClosedReports': True,
+}
+
 
 @pytest.fixture()
 def describe_report_definitions_response_invalid():
@@ -528,6 +539,7 @@ def test_handler_exception(context):
 @pytest.mark.parametrize('report_definitions,expected_format', [
     ({'ReportDefinitions': [PARQUET_REPORT]}, 'aws_parquet'),
     ({'ReportDefinitions': [PARQUET_REPORT, CSV_REPORT]}, 'aws'),
+    ({'ReportDefinitions': [PARQUET_REPORT, MINIMUM_CSV_REPORT]}, 'aws'),  # ideal Parquet + minimum CSV → CSV wins
 ])
 def test_handler_cur_format_detection(context, cfn_event, describe_trails_response_local, list_buckets_response, describe_organizations_local, report_definitions, expected_format):
     context.mock_ct.describe_trails.return_value = describe_trails_response_local

--- a/services/discovery/tests/unit/test_app.py
+++ b/services/discovery/tests/unit/test_app.py
@@ -280,6 +280,7 @@ def test_handler_all_local(context, cfn_event, describe_trails_response_local, l
         'IsOrganizationMasterAccount': True,
         'MasterPayerBillingBucketName': LOCAL_BUCKET_NAME,
         'MasterPayerBillingBucketPath': 'reports/valid-local-report',
+        'BillingReportFormat': 'aws',
         'RemoteCloudTrailBucket': False,
         'IsAccountOutsideOrganization': False,
     }
@@ -311,6 +312,7 @@ def test_handler_non_audit(context, cfn_event, describe_trails_response_remote_b
         'IsOrganizationMasterAccount': True,
         'MasterPayerBillingBucketName': LOCAL_BUCKET_NAME,
         'MasterPayerBillingBucketPath': 'reports/valid-local-report',
+        'BillingReportFormat': 'aws',
         'IsAccountOutsideOrganization': False,
     }
 
@@ -341,6 +343,7 @@ def test_handler_remote_organization_trail(context, cfn_event, describe_trails_r
         'IsOrganizationMasterAccount': True,
         'MasterPayerBillingBucketName': LOCAL_BUCKET_NAME,
         'MasterPayerBillingBucketPath': 'reports/valid-local-report',
+        'BillingReportFormat': 'aws',
         'IsAccountOutsideOrganization': False,
     }
 
@@ -371,6 +374,7 @@ def test_handler_master_payer_with_no_valid_reports(context, cfn_event, describe
         'IsOrganizationMasterAccount': True,
         'MasterPayerBillingBucketName': None,
         'MasterPayerBillingBucketPath': None,
+        'BillingReportFormat': 'aws',
         'IsAccountOutsideOrganization': False,
     }
 
@@ -401,6 +405,7 @@ def test_handler_master_payer_outside_organization(context, cfn_event, describe_
         'IsOrganizationMasterAccount': False,
         'MasterPayerBillingBucketName': None,
         'MasterPayerBillingBucketPath': None,
+        'BillingReportFormat': 'aws',
         'IsAccountOutsideOrganization': True,
     }
 
@@ -432,6 +437,7 @@ def test_handler_master_payer_remote(context, cfn_event, describe_trails_respons
         'IsOrganizationMasterAccount': False,
         'MasterPayerBillingBucketName': None,
         'MasterPayerBillingBucketPath': None,
+        'BillingReportFormat': 'aws',
         'IsAccountOutsideOrganization': False,
     }
 
@@ -462,6 +468,7 @@ def test_handler_just_resource_owner(context, cfn_event, list_buckets_response, 
         'IsOrganizationMasterAccount': False,
         'MasterPayerBillingBucketName': None,
         'MasterPayerBillingBucketPath': None,
+        'BillingReportFormat': 'aws',
         'IsAccountOutsideOrganization': False,
     }
 

--- a/services/discovery/tests/unit/test_app.py
+++ b/services/discovery/tests/unit/test_app.py
@@ -198,6 +198,34 @@ def describe_report_definitions_response_remote():
     }
 
 
+PARQUET_REPORT = {
+    'ReportName': 'valid-parquet-report',
+    'TimeUnit': 'HOURLY',
+    'Format': 'Parquet',
+    'Compression': 'Parquet',
+    'AdditionalSchemaElements': ['RESOURCES'],
+    'S3Bucket': LOCAL_BUCKET_NAME,
+    'S3Prefix': 'reports',
+    'S3Region': 'us-east-1',
+    'RefreshClosedReports': True,
+    'ReportVersioning': 'CREATE_NEW_REPORT',
+}
+
+CSV_REPORT = {
+    'ReportName': 'valid-csv-report',
+    'TimeUnit': 'HOURLY',
+    'Format': 'textORcsv',
+    'Compression': 'GZIP',
+    'AdditionalSchemaElements': ['RESOURCES'],
+    'S3Bucket': LOCAL_BUCKET_NAME,
+    'S3Prefix': 'reports',
+    'S3Region': 'us-east-1',
+    'RefreshClosedReports': True,
+    'ReportVersioning': 'CREATE_NEW_REPORT',
+}
+
+
+
 @pytest.fixture()
 def describe_report_definitions_response_invalid():
     return {
@@ -495,3 +523,22 @@ def test_handler_exception(context):
     ((_, _, status, output, _), kwargs) = context.mock_cfnresponse_send.call_args
     assert status == cfnresponse.SUCCESS
     assert output == app.DEFAULT_OUTPUT
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('report_definitions,expected_format', [
+    ({'ReportDefinitions': [PARQUET_REPORT]}, 'aws_parquet'),
+    ({'ReportDefinitions': [PARQUET_REPORT, CSV_REPORT]}, 'aws'),
+])
+def test_handler_cur_format_detection(context, cfn_event, describe_trails_response_local, list_buckets_response, describe_organizations_local, report_definitions, expected_format):
+    context.mock_ct.describe_trails.return_value = describe_trails_response_local
+    context.mock_cur.describe_report_definitions.return_value = report_definitions
+    context.mock_orgs.describe_organization.return_value = describe_organizations_local
+    context.mock_s3.list_buckets.return_value = list_buckets_response
+    ret = app.handler(cfn_event, None)
+    assert ret is None
+    ((_, _, status, output, _), _) = context.mock_cfnresponse_send.call_args
+    assert status == cfnresponse.SUCCESS
+    assert output['BillingReportFormat'] == expected_format
+    assert output['MasterPayerBillingBucketName'] == LOCAL_BUCKET_NAME
+    assert output['IsMasterPayerAccount'] is True

--- a/services/notification/src/app.py
+++ b/services/notification/src/app.py
@@ -40,6 +40,7 @@ DEFAULT_CFN_COEFFECT = {
         'IsResourceOwnerAccount': 'false',
         'MasterPayerBillingBucketName': 'null',
         'MasterPayerBillingBucketPath': 'null',
+        'BillingReportFormat': 'aws',
         'RemoteCloudTrailBucket': 'true',
     },
     'MasterPayerAccount': {
@@ -113,6 +114,7 @@ CFN_COEFFECT_SCHEMA = Schema({
         'IsResourceOwnerAccount': BOOLEAN_STRING,
         'MasterPayerBillingBucketName': NULLABLE_STRING,
         'MasterPayerBillingBucketPath': NULLABLE_STRING,
+        'BillingReportFormat': NULLABLE_STRING,
         'RemoteCloudTrailBucket': BOOLEAN_STRING,
     },
     'MasterPayerAccount': {
@@ -302,6 +304,7 @@ def prepare_output(world):
                 'cz_account_name': metadata['AccountName'],
                 'reactor_id': metadata['ReactorId'],
                 'reactor_callback_url': metadata['ReactorCallbackUrl'],
+                'billing_report_format': null_to_none(get_in(['Discovery', 'BillingReportFormat'], valid_cfn)) or 'aws',
             },
             'links': {
                 'audit': {'role_arn': null_to_none(get_in(['AuditAccount', 'RoleArn'], valid_cfn))},

--- a/services/notification/src/app.py
+++ b/services/notification/src/app.py
@@ -144,6 +144,7 @@ ACCOUNT_LINK_PROVISIONED = Schema({
             'cz_account_name': str,
             'reactor_id': str,
             'reactor_callback_url': str,
+            'billing_report_format': NONEABLE_STRING,
         },
         'links': {
             'audit': LINK_ROLE,

--- a/services/notification/tests/unit/test_app.py
+++ b/services/notification/tests/unit/test_app.py
@@ -165,6 +165,7 @@ def test_handler_no_cfn_coeffects(context, cfn_event):
                 'reactor_callback_url': EXPECTED_URL,
                 'external_id': 'str',
                 'reactor_id': 'str',
+                'billing_report_format': 'aws',
             },
             'links': {
                 'audit': {'role_arn': None},

--- a/services/notification/tests/unit/test_app.py
+++ b/services/notification/tests/unit/test_app.py
@@ -84,6 +84,7 @@ def cfn_coeffect():
             'IsResourceOwnerAccount': boolean_string(),
             'MasterPayerBillingBucketName': nullable_string(),
             'MasterPayerBillingBucketPath': nullable_string(),
+            'BillingReportFormat': nullable_string(),
             'RemoteCloudTrailBucket': boolean_string(),
         },
         'MasterPayerAccount': {
@@ -193,5 +194,24 @@ def test_prepare_output(context, cfn_event, cfn_coeffect):
         'valid_cfn': cfn_coeffect,
     }
     is_master_payer_account = bool(cfn_coeffect['Discovery']['IsMasterPayerAccount'] == 'True')
+    raw_format = cfn_coeffect['Discovery']['BillingReportFormat']
+    expected_billing_format = 'aws' if raw_format == 'null' else raw_format
     new_world = app.prepare_output(world)
     assert new_world['output']['data']['discovery']['is_master_payer_account'] == is_master_payer_account
+    assert new_world['output']['data']['metadata']['billing_report_format'] == expected_billing_format
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('raw_format,expected', [
+    ('aws_parquet', 'aws_parquet'),
+    ('null', 'aws'),
+    ('aws', 'aws'),
+])
+def test_prepare_output_billing_format(context, cfn_event, cfn_coeffect, raw_format, expected):
+    cfn_coeffect['Discovery']['BillingReportFormat'] = raw_format
+    world = {
+        'event': cfn_event,
+        'valid_cfn': cfn_coeffect,
+    }
+    new_world = app.prepare_output(world)
+    assert new_world['output']['data']['metadata']['billing_report_format'] == expected


### PR DESCRIPTION
## Description of the change

 Since `provision-account` is customer-deployed, the blast radius is limited to accounts that run a stack update after the new version hits S3. Accounts that haven't updated yet are completely unaffected.
The rollback risk is low.

  **Here's why it's safe to merge:**                                                                                                  
  - `reactor-account-manager` receives `billing_report_format: aws_parquet` and stores/passes it along — it doesn't crash or reject it because the field is `Optional`                          
  - Nothing in the current downstream stack acts differently on `aws_parquet` yet, so Parquet customers are in the same state as before — no worse, no better                              
  - When I merge the `cz-billing-ingest` PR, it will start reading `billing_report_format` and routing correctly — at that point the full flow is live                                      
  - CSV customers are completely unaffected throughout all of this                             
This PR just ensures the signal (`aws_parquet`) is in the provisioning message when the ingest side is ready to consume it. 

### Testing
**Unit tests**                                                                                   
  - Parquet-only CUR → `aws_parquet`                                                           
  - Ideal Parquet + ideal CSV → CSV wins → `aws`                                                 
  - Ideal Parquet + minimum CSV → CSV wins → `aws` (the Greptile bug case)                     
  - Notification forwards `aws_parquet` correctly                                                
  - Notification forwards `aws` correctly                                                        
  - Missing BillingReportFormat defaults to aws                                                
  - No Discovery stack coeffects → billing_report_format: `aws` in metadata                      
                                                                                               
  **Discovery Lambda — live (cz-test-org-master, 809893965069)**                                   
  - Ideal CSV + Parquet CURs present → CSV wins → BillingReportFormat: `aws`                     
  - Parquet-only CUR → BillingReportFormat: `aws_parquet`                                        
  - Ideal Parquet + minimum CSV → CSV wins → BillingReportFormat: `aws`                          
  - CSV-only CUR → BillingReportFormat: `aws`                                                    
  - No CloudZero CUR present (third-party Parquet CURs in account) → BillingReportFormat: `aws_parquet`                                                                            
  - CFN stack update → BillingReportFormat: `aws_parquet` appears as a real CloudFormation stack output                                                                                      
                                                                                               
  Notification Lambda — live (cz-test-org-master, 809893965069)
  - Discovery stack with BillingReportFormat: aws_parquet → billing_report_format: `aws_parquet` present in account-link-provisioned payload                                                  
  - Nonexistent/old Discovery stack (no BillingReportFormat output) → defaults to              
  billing_report_format: `aws`, no crash                                                         
                                                                                               
  **Breaking change assertions**                       
  - Invalid BillingReportFormat value → passes through without crash, schema does not reject it
  - Old Discovery stack with no BillingReportFormat → notification Lambda gracefully defaults to `aws`
  -       
This PR adds native Parquet CUR support to the discovery and notification services. Discovery gains four tiered schemas (IDEAL/MINIMUM × CSV/Parquet) evaluated in order with all CSV tiers before any Parquet tier, ensuring CSV always wins when both formats are present. Notification reads the new BillingReportFormat stack output and forwards it in the account-link-provisioned message, defaulting to 'aws'.

https://cloudzero.atlassian.net/wiki/spaces/ENG/pages/5784535041/RFR+AWS+CUR+Parquet+Ingest+Support

> Did something awesome w/out a breaking change.

## Type of change
- [ ] Bug fix
- [ ] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
