### PR TITLE
Fix Version Latest Lambda Code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,15 +198,29 @@ deploy-bucket:
 	done
 
 
+# Uploads CFN templates, IAM policies, and SAM-built Lambda zips to s3://$(BUCKET)/$(path)/.
+# If `substitute_version` is set, YAML/JSON files are piped through `sed s|${Version}|<sub>|g`
+# before upload. Used for the `latest/` path so the published templates reference a specific
+# versioned S3 key for the Lambda code: without that substitution, `CodeUri.Key` stays as the
+# literal string `latest/services/discovery.zip` across releases, and since CFN compares
+# CodeUri as a string (not by S3 object content) customer Update events never refresh the
+# Lambda code.
 copy-to-s3: guard-path
-	@for key in $(CFN_TEMPLATES) $(IAM_POLICIES) ; do \
-		aws s3 cp $${key} s3://$(BUCKET)/$(path)/$${key} ; \
+	@upload() { \
+		if [ -n "$(substitute_version)" ]; then \
+			sed 's|$${Version}|$(substitute_version)|g' "$$1" | aws s3 cp - "$$2" ; \
+		else \
+			aws s3 cp "$$1" "$$2" ; \
+		fi ; \
+	} ; \
+	for key in $(CFN_TEMPLATES) $(IAM_POLICIES) ; do \
+		upload "$${key}" "s3://$(BUCKET)/$(path)/$${key}" ; \
 	done && \
 	for app in $(SAM_APPS) ; do \
-		aws s3 cp $${app}/$(TEMPLATE_FILE) s3://$(BUCKET)/$(path)/$${app}.yaml && \
-		aws s3 cp $${app}/$(APP_ZIP) s3://$(BUCKET)/$(path)/$${app}.zip && \
+		upload "$${app}/$(TEMPLATE_FILE)" "s3://$(BUCKET)/$(path)/$${app}.yaml" && \
+		aws s3 cp "$${app}/$(APP_ZIP)" "s3://$(BUCKET)/$(path)/$${app}.zip" && \
 		for r in $(regions) ; do \
-			aws s3 cp $${app}/$(APP_ZIP) s3://$(BUCKET)-$${r}/$(path)/$${app}.zip ; \
+			aws s3 cp "$${app}/$(APP_ZIP)" "s3://$(BUCKET)-$${r}/$(path)/$${app}.zip" ; \
 		done ; \
 	done
 
@@ -216,7 +230,8 @@ deploy:
 	find . -name $(APP_ZIP) -exec rm -rf {} \; && \
 	$(MAKE) package-sam-apps && \
 	$(MAKE) copy-to-s3 path=v$(SEMVER_MAJ_MIN).$(version) && \
-	[ $(version) != 'dev' ] && $(MAKE) copy-to-s3 path=latest || true
+	[ $(version) != 'dev' ] && \
+		$(MAKE) copy-to-s3 path=latest substitute_version=v$(SEMVER_MAJ_MIN).$(version) || true
 
 .PHONY: update-dev
 update-dev:

--- a/Makefile
+++ b/Makefile
@@ -199,25 +199,17 @@ deploy-bucket:
 
 
 # Uploads CFN templates, IAM policies, and SAM-built Lambda zips to s3://$(BUCKET)/$(path)/.
-# If `substitute_version` is set, YAML/JSON files are piped through `sed s|${Version}|<sub>|g`
-# before upload. Used for the `latest/` path so the published templates reference a specific
-# versioned S3 key for the Lambda code: without that substitution, `CodeUri.Key` stays as the
-# literal string `latest/services/discovery.zip` across releases, and since CFN compares
-# CodeUri as a string (not by S3 object content) customer Update events never refresh the
-# Lambda code.
+# YAML/JSON files are piped through sed to rewrite `${Version}` references with the build's
+# semver before upload, so customer stacks on the `latest/` path see a different `CodeUri.Key`
+# every release. Without this rewrite the resolved key stays `latest/services/discovery.zip`
+# across releases and CFN — which compares CodeUri as a string, not by S3 object content —
+# never refreshes the Lambda code.
 copy-to-s3: guard-path
-	@upload() { \
-		if [ -n "$(substitute_version)" ]; then \
-			sed 's|$${Version}|$(substitute_version)|g' "$$1" | aws s3 cp - "$$2" ; \
-		else \
-			aws s3 cp "$$1" "$$2" ; \
-		fi ; \
-	} ; \
-	for key in $(CFN_TEMPLATES) $(IAM_POLICIES) ; do \
-		upload "$${key}" "s3://$(BUCKET)/$(path)/$${key}" ; \
+	@for key in $(CFN_TEMPLATES) $(IAM_POLICIES) ; do \
+		sed 's|$${Version}|v$(SEMVER_MAJ_MIN).$(version)|g' "$${key}" | aws s3 cp - "s3://$(BUCKET)/$(path)/$${key}" ; \
 	done && \
 	for app in $(SAM_APPS) ; do \
-		upload "$${app}/$(TEMPLATE_FILE)" "s3://$(BUCKET)/$(path)/$${app}.yaml" && \
+		sed 's|$${Version}|v$(SEMVER_MAJ_MIN).$(version)|g' "$${app}/$(TEMPLATE_FILE)" | aws s3 cp - "s3://$(BUCKET)/$(path)/$${app}.yaml" && \
 		aws s3 cp "$${app}/$(APP_ZIP)" "s3://$(BUCKET)/$(path)/$${app}.zip" && \
 		for r in $(regions) ; do \
 			aws s3 cp "$${app}/$(APP_ZIP)" "s3://$(BUCKET)-$${r}/$(path)/$${app}.zip" ; \
@@ -230,8 +222,7 @@ deploy:
 	find . -name $(APP_ZIP) -exec rm -rf {} \; && \
 	$(MAKE) package-sam-apps && \
 	$(MAKE) copy-to-s3 path=v$(SEMVER_MAJ_MIN).$(version) && \
-	[ $(version) != 'dev' ] && \
-		$(MAKE) copy-to-s3 path=latest substitute_version=v$(SEMVER_MAJ_MIN).$(version) || true
+	[ $(version) != 'dev' ] && $(MAKE) copy-to-s3 path=latest || true
 
 .PHONY: update-dev
 update-dev:

--- a/docs/releases/1.0.97.md
+++ b/docs/releases/1.0.97.md
@@ -1,0 +1,20 @@
+# [1.0.97](https://github.com/Cloudzero/provision-account/compare/1.0.96...1.0.97) (2026-05-19)
+
+> Fix Lambda code refresh on `update-stack` for stacks deployed with `Version=latest`
+
+## Bug Fixes
+
+### Lambda code now refreshes on `update-stack`
+Stacks deployed with `Version=latest` now refresh the underlying Lambda code on each `update-stack`. Previously the resolved `CodeUri.Key` did not change between releases, so CloudFormation skipped the Lambda code update. Customers who saw `UPDATE_ROLLBACK_COMPLETE` with a `Vendor response doesn't contain <attribute> attribute` error should re-run `update-stack` after this release — no stack recreate is needed.
+
+## Files Modified
+
+- `Makefile`
+- `services/discovery/template.yaml`
+- `services/connected_account.yaml`
+- `services/connected_account_dev.yaml`
+
+## Deployment Notes
+
+* No customer action required.
+* Customers pinned to a specific `Version=<semver>` are unaffected.

--- a/services/connected_account.yaml
+++ b/services/connected_account.yaml
@@ -155,7 +155,7 @@ Resources:
         Value: !FindInMap [CallbackConfiguration, prod, ReactorAccountId]
       ServiceToken: !GetAtt NotificationFunctionStack.Outputs.Arn
       AccountId: !Ref AWS::AccountId
-      Version: '1'
+      Version: !Sub ${Version}
       # Parameters from Other Resources in this Stack
       ExternalId: !Ref ExternalId
       ReactorCallbackUrl: !FindInMap [CallbackConfiguration, prod, ReactorCallbackUrl]

--- a/services/connected_account_dev.yaml
+++ b/services/connected_account_dev.yaml
@@ -155,7 +155,7 @@ Resources:
         Value: !FindInMap [CallbackConfiguration, dev, ReactorAccountId]
       ServiceToken: !GetAtt NotificationFunctionStack.Outputs.Arn
       AccountId: !Ref AWS::AccountId
-      Version: '1'
+      Version: !Sub ${Version}
       # Parameters from Other Resources in this Stack
       ExternalId: !Ref ExternalId
       ReactorCallbackUrl: !FindInMap [CallbackConfiguration, dev, ReactorCallbackUrl]

--- a/services/discovery/template.yaml
+++ b/services/discovery/template.yaml
@@ -47,7 +47,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt DiscoveryFunction.Arn
       AccountId: !Sub ${AWS::AccountId}
-      Version: '20230523'
+      Version: !Sub ${Version}
 
 Outputs:
   AuditCloudTrailBucketName:


### PR DESCRIPTION
## Description of the change

Fixes CP-41833. Customer stacks deployed with `Version=latest` were running with frozen Lambda code because CloudFormation compares `CodeUri` as a string and `latest/services/discovery.zip` never changed across releases. Template changes that referenced new Lambda response attributes (e.g. `BillingReportFormat` from CP-40732) then failed customer `update-stack` with `Vendor response doesn't contain <attr> attribute` and rolled back.

### What changed

**Makefile (`copy-to-s3`)** — All text files (CFN templates, SAM app templates, IAM policy JSON) are now piped through `sed 's|${Version}|v1.0.<N>|g'` before upload, where `<N>` is the current build's git rev count; zip files are copied unchanged. The deploy target uploads to both the versioned path (`v1.0.<N>/`) and `latest/`. Both copies have the semver baked into `${Version}` references — versioned was already path-locked to that semver, so its resolved CodeUri is identical; the load-bearing change is that `latest/` now points at versioned S3 paths for inner templates and Lambda zips, so the resolved CodeUri Key differs each release and CFN refreshes the Lambda.

**`services/discovery/template.yaml` and `services/connected_account{,_dev}.yaml`** — `Version` properties on the `Custom::Discovery` and `Custom::NotifyCloudZero` resources changed from hardcoded literals (`'20230523'` and `'1'`) to `!Sub ${Version}`, which sed then resolves at build time. All three files retain their `Version` CFN parameter with default `latest`, so the source templates remain valid for direct stack deploys as well.
